### PR TITLE
Fix VIDEO_MEMORY volatility

### DIFF
--- a/kernel.c
+++ b/kernel.c
@@ -1,7 +1,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-static uint16_t* const VIDEO_MEMORY = (uint16_t*)0xB8000;
+static volatile uint16_t* const VIDEO_MEMORY = (volatile uint16_t*)0xB8000;
 
 void kernel_main(void) {
     const char* message = "Hello from SimpleKernel!";


### PR DESCRIPTION
## Summary
- make VIDEO_MEMORY volatile in kernel.c so writes aren't optimized away

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6845fc972f0c8330aab93ffd2b741805